### PR TITLE
Update policy to L1 4096

### DIFF
--- a/policy/src/loader.rs
+++ b/policy/src/loader.rs
@@ -117,8 +117,7 @@ fn parse_into_buffer(game: MontyFormat, buffer: &mut Vec<DecompressedData>) {
     let castling = game.castling;
 
     for data in game.moves {
-        if (data.score - 0.5).abs() > 0.49 {
-        } else if let Some(dist) = data.visit_distribution.as_ref() {
+        if let Some(dist) = data.visit_distribution.as_ref() {
             if dist.len() > 1 && dist.len() <= MAX_MOVES {
                 let mut policy_data = DecompressedData {
                     pos,

--- a/policy/src/main.rs
+++ b/policy/src/main.rs
@@ -15,9 +15,9 @@ use trainer::Trainer;
 const ID: &str = "policy001";
 
 fn main() {
-    let data_preparer = preparer::DataPreparer::new("../binpacks/policygen9.binpack", 4096);
+    let data_preparer = preparer::DataPreparer::new("/home/privateclient/monty_value_training/interleaved-policy.binpack", 96000);
 
-    let size = 512;
+    let size = 4096;
 
     let mut graph = network(size);
 
@@ -39,15 +39,15 @@ fn main() {
             batch_size: 16_384,
             batches_per_superbatch: 6104,
             start_superbatch: 1,
-            end_superbatch: 540,
+            end_superbatch: 300,
         },
         wdl_scheduler: wdl::ConstantWDL { value: 0.0 },
         lr_scheduler: lr::ExponentialDecayLR {
             initial_lr: 0.001,
-            final_lr: 0.000001,
-            final_superbatch: 540,
+            final_lr: 0.00001,
+            final_superbatch: 300,
         },
-        save_rate: 10,
+        save_rate: 40,
     };
 
     let settings = LocalSettings {


### PR DESCRIPTION
Increases the policy L1 size from 2048 to 4096. Also includes winning positions in training, and only drops from 1e-3 to 1e-5 over the 300 superbatches to increase convergence.

Binpacks used: All Policygen8 data from https://huggingface.co/datasets/Viren6/MontyPolicy