### PR TITLE
Update value net to WDL outputs and PSQT subnet

### DIFF
--- a/value/src/arch.rs
+++ b/value/src/arch.rs
@@ -39,6 +39,8 @@ pub fn make_trainer(l1: usize) -> Trainer<AdamWOptimiser, ThreatInputs, outputs:
             ("l2b".to_string(), QuantTarget::Float),
             ("l3w".to_string(), QuantTarget::Float),
             ("l3b".to_string(), QuantTarget::Float),
+            ("pstw".to_string(), QuantTarget::Float),
+            ("pstb".to_string(), QuantTarget::Float),
         ],
     )
 }
@@ -48,17 +50,19 @@ fn build_network(inputs: usize, l1: usize) -> (Graph, Node) {
 
     // inputs
     let stm = builder.create_input("stm", Shape::new(inputs, 1));
-    let targets = builder.create_input("targets", Shape::new(1, 1));
+    let targets = builder.create_input("targets", Shape::new(3, 1));
 
     // trainable weights
+    let pstw = builder.create_weights("pstw", Shape::new(3, inputs));
+    let pstb = builder.create_weights("pstb", Shape::new(3, 1));
     let l0w = builder.create_weights("l0w", Shape::new(l1, inputs));
     let l0b = builder.create_weights("l0b", Shape::new(l1, 1));
     let l1w = builder.create_weights("l1w", Shape::new(16, l1));
     let l1b = builder.create_weights("l1b", Shape::new(16, 1));
     let l2w = builder.create_weights("l2w", Shape::new(128, 16));
     let l2b = builder.create_weights("l2b", Shape::new(128, 1));
-    let l3w = builder.create_weights("l3w", Shape::new(1, 128));
-    let l3b = builder.create_weights("l3b", Shape::new(1, 1));
+    let l3w = builder.create_weights("l3w", Shape::new(3, 128));
+    let l3b = builder.create_weights("l3b", Shape::new(3, 1));
 
     // inference
     let l1 = operations::affine(&mut builder, l0w, stm, l0b);
@@ -67,9 +71,12 @@ fn build_network(inputs: usize, l1: usize) -> (Graph, Node) {
     let l2 = operations::activate(&mut builder, l2, Activation::SCReLU);
     let l3 = operations::affine(&mut builder, l2w, l2, l2b);
     let l3 = operations::activate(&mut builder, l3, Activation::SCReLU);
-    let predicted = operations::affine(&mut builder, l3w, l3, l3b);
-    let sigmoided = operations::activate(&mut builder, predicted, Activation::Sigmoid);
-    operations::mse(&mut builder, sigmoided, targets);
+    let l4 = operations::affine(&mut builder, l3w, l3, l3b);
+
+    let pst = operations::affine(&mut builder, pstw, stm, pstb);
+
+    let predicted = operations::add(&mut builder, l4, pst);
+    operations::softmax_crossentropy_loss(&mut builder, predicted, targets);
 
     // graph, output node
     (builder.build(ExecutionContext::default()), predicted)

--- a/value/src/main.rs
+++ b/value/src/main.rs
@@ -17,15 +17,15 @@ fn main() {
             batch_size: 16_384,
             batches_per_superbatch: 6104,
             start_superbatch: 1,
-            end_superbatch: 3000,
+            end_superbatch: 3600,
         },
         wdl_scheduler: wdl::ConstantWDL { value: 1.0 },
         lr_scheduler: lr::ExponentialDecayLR {
             initial_lr: 0.001,
-            final_lr: 0.0000001,
-            final_superbatch: 3000,
+            final_lr: 0.0000005,
+            final_superbatch: 3600,
         },
-        save_rate: 20,
+        save_rate: 40,
     };
 
     let optimiser_params = optimiser::AdamWParams {
@@ -45,7 +45,7 @@ fn main() {
         batch_queue_size: 256,
     };
 
-    let data_loader = loader::BinpackLoader::new("../binpacks/bestmove-q.binpack", 48000);
+    let data_loader = loader::BinpackLoader::new("/home/privateclient/monty_value_training/interleaved-value.binpack", 96000);
 
     trainer.run(&schedule, &settings, &data_loader);
 


### PR DESCRIPTION
Implements WDL outputs and PSQT subnet. Trained for 3600SB with LR starting at 1e-3 and exponentially decaying to 5e-7. It was measured that these changes increase training convergence rate and also that LR below 1e-5 is still worth 10+ Elo.

Binpacks used: All data from https://huggingface.co/datasets/Viren6/MontyValue2 and all Datagen16 data from https://huggingface.co/datasets/Viren6/MontyValue