### PR TITLE
Update value net to use pairwise

### DIFF
--- a/value/src/arch.rs
+++ b/value/src/arch.rs
@@ -53,7 +53,7 @@ fn build_network(inputs: usize, l1: usize) -> (Graph, Node) {
     // trainable weights
     let l0w = builder.create_weights("l0w", Shape::new(l1, inputs));
     let l0b = builder.create_weights("l0b", Shape::new(l1, 1));
-    let l1w = builder.create_weights("l1w", Shape::new(16, l1));
+    let l1w = builder.create_weights("l1w", Shape::new(16, l1 / 2));
     let l1b = builder.create_weights("l1b", Shape::new(16, 1));
     let l2w = builder.create_weights("l2w", Shape::new(128, 16));
     let l2b = builder.create_weights("l2b", Shape::new(128, 1));
@@ -62,7 +62,8 @@ fn build_network(inputs: usize, l1: usize) -> (Graph, Node) {
 
     // inference
     let l1 = operations::affine(&mut builder, l0w, stm, l0b);
-    let l1 = operations::activate(&mut builder, l1, Activation::SCReLU);
+    let l1 = operations::activate(&mut builder, l1, Activation::CReLU);
+    let l1 = operations::pairwise_mul(&mut builder, l1);
     let l2 = operations::affine(&mut builder, l1w, l1, l1b);
     let l2 = operations::activate(&mut builder, l2, Activation::SCReLU);
     let l3 = operations::affine(&mut builder, l2w, l2, l2b);

--- a/value/src/main.rs
+++ b/value/src/main.rs
@@ -5,7 +5,7 @@ mod loader;
 use arch::make_trainer;
 use bullet::{lr, optimiser, wdl, LocalSettings, TrainingSchedule, TrainingSteps};
 
-const HIDDEN_SIZE: usize = 4096;
+const HIDDEN_SIZE: usize = 6144;
 
 fn main() {
     let mut trainer = make_trainer(HIDDEN_SIZE);
@@ -17,13 +17,13 @@ fn main() {
             batch_size: 16_384,
             batches_per_superbatch: 6104,
             start_superbatch: 1,
-            end_superbatch: 3600,
+            end_superbatch: 2400,
         },
         wdl_scheduler: wdl::ConstantWDL { value: 1.0 },
         lr_scheduler: lr::ExponentialDecayLR {
             initial_lr: 0.001,
             final_lr: 0.0000005,
-            final_superbatch: 3600,
+            final_superbatch: 2400,
         },
         save_rate: 40,
     };


### PR DESCRIPTION
Makes Value L1 pairwise and 6144 instead of 4096 neurons. Reducing SB from 3600 to 2400 as training is 50% slower per SB.

Binpacks used: All data from https://huggingface.co/datasets/Viren6/MontyValue2 and all Datagen16 data from https://huggingface.co/datasets/Viren6/MontyValue