### PR TITLE
Update policy net to use hm and pairwise

### DIFF
--- a/policy/src/bin/interleave.rs
+++ b/policy/src/bin/interleave.rs
@@ -6,7 +6,7 @@ use std::{
 use montyformat::{MontyFormat, FastDeserialise};
 
 fn main() -> std::io::Result<()> {
-    let folder_path = "/home/neural/policy_data/64"; // Specify the folder to scan
+    let folder_path = "/home/privateclient/monty_value_training/monty-policy-data"; // Specify the folder to scan
     let output = "interleaved.binpack";
 
     // Scan the folder and collect file paths with the specified extension

--- a/policy/src/inputs.rs
+++ b/policy/src/inputs.rs
@@ -5,6 +5,7 @@ pub const MAX_ACTIVE: usize = 32;
 
 pub fn map_policy_inputs<F: FnMut(usize)>(pos: &Position, mut f: F) {
     let flip = pos.stm() == Side::BLACK;
+    let hm = if pos.king_index() % 8 > 3 { 7 } else { 0 };
 
     let mut threats = pos.threats_by(pos.stm() ^ 1);
     let mut defences = pos.threats_by(pos.stm());
@@ -27,7 +28,7 @@ pub fn map_policy_inputs<F: FnMut(usize)>(pos: &Position, mut f: F) {
 
         while our_bb > 0 {
             let sq = our_bb.trailing_zeros();
-            let mut feat = pc + sq as usize;
+            let mut feat = pc + (sq ^ hm) as usize;
 
             let bit = 1 << sq;
             if threats & bit > 0 {
@@ -45,7 +46,7 @@ pub fn map_policy_inputs<F: FnMut(usize)>(pos: &Position, mut f: F) {
 
         while opp_bb > 0 {
             let sq = opp_bb.trailing_zeros();
-            let mut feat = 384 + pc + sq as usize;
+            let mut feat = 384 + pc + (sq ^ hm) as usize;
 
             let bit = 1 << sq;
             if threats & bit > 0 {

--- a/policy/src/moves.rs
+++ b/policy/src/moves.rs
@@ -5,18 +5,19 @@ pub const NUM_MOVES: usize = 2 * (OFFSETS[64] + PROMOS);
 pub const PROMOS: usize = 4 * 22;
 
 pub fn map_move_to_index(pos: &Position, mov: Move) -> usize {
+    let hm = if pos.king_index() % 8 > 3 { 7 } else { 0 };
     let good_see = (OFFSETS[64] + PROMOS) * usize::from(see(pos, &mov, -108));
 
     let idx = if mov.is_promo() {
-        let ffile = mov.src() % 8;
-        let tfile = mov.to() % 8;
+        let ffile = (mov.src() ^ hm) % 8;
+        let tfile = (mov.to() ^ hm) % 8;
         let promo_id = 2 * ffile + tfile;
 
         OFFSETS[64] + 22 * (mov.promo_pc() - Piece::KNIGHT) + usize::from(promo_id)
     } else {
         let flip = if pos.stm() == Side::BLACK { 56 } else { 0 };
-        let from = usize::from(mov.src() ^ flip);
-        let dest = usize::from(mov.to() ^ flip);
+        let from = usize::from(mov.src() ^ flip ^ hm);
+        let dest = usize::from(mov.to() ^ flip ^ hm);
 
         let below = ALL_DESTINATIONS[from] & ((1 << dest) - 1);
 


### PR DESCRIPTION
Makes Policy hm and L1 pairwise and 6144 instead of 4096 neurons. Increases SB from 300 to 600.

Binpacks used: All data from https://huggingface.co/datasets/Viren6/MontyPolicy2