### PR TITLE
Update policy net to L1 12288

### DIFF
--- a/policy/src/main.rs
+++ b/policy/src/main.rs
@@ -17,7 +17,7 @@ const ID: &str = "policy001";
 fn main() {
     let data_preparer = preparer::DataPreparer::new("/home/privateclient/monty_value_training/interleaved.binpack", 96000);
 
-    let size = 6144;
+    let size = 12288;
 
     let mut graph = network(size);
 


### PR DESCRIPTION
Doubled Policy L1 from 6144 to 12288. Same settings and dataset as the previous policy net.